### PR TITLE
:recycle: Removes '/apoioaempresas' from devise links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,6 @@ class ApplicationController < ActionController::Base
 
   # Overwriting the sign_out redirect path method
   def after_sign_out_path_for(_resource_or_scope)
-    login_path
+    new_user_session_path
   end
 end

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -45,7 +45,7 @@ class CallsController < ApplicationController
         @calls = []
       end
     else
-      redirect_to login_path
+      redirect_to new_user_session_path
     end
     # puts params[:filterrific].require(:filtered_by)
     respond_to do |format|

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,7 @@
 
 class WelcomeController < ApplicationController
   def index
-    redirect_to(login_path) && return if user_signed_in?
+    redirect_to(new_user_session_path) && return if user_signed_in?
     render layout: 'welcome'
   end
 end

--- a/app/views/layouts/_auth_application.html.erb
+++ b/app/views/layouts/_auth_application.html.erb
@@ -88,10 +88,6 @@
               <i class="fa fa-bell icon"></i>
               Notificações
             </a>
-            <!-- <a class="dropdown-item" href="#">
-              <i class="fa fa-gear icon"></i>
-              Settings
-            </a> -->
             <div class="dropdown-divider"></div>
             <%= link_to destroy_user_session_path, :method=>'delete' , class: 'dropdown-item' do %>
             <i class="fa fa-power-off icon"></i>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -26,7 +26,7 @@
     </div>
   </div>
   <div class="text-center">
-    <%= link_to(login_path, class: 'btn btn-secondary btn-sm') do%>
+    <%= link_to(new_user_session_path, class: 'btn btn-secondary btn-sm') do%>
       <i class="fa fa-arrow-left"></i>
       Voltar
     <%end%>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -31,7 +31,7 @@
             <div class="banner-text text-center">
               <h1 class="white">PIUBS</h1>
               <p>Programa de Informatização das Unidades Básicas de Saúde</p>
-              <%= link_to 'Apoio à empresas',login_path, class: 'btn btn-appoint btn-lg'%>
+              <%= link_to 'Apoio à empresas', new_user_session_path, class: 'btn btn-appoint btn-lg'%>
               <a href="#contact" disabled="disabled" class="btn btn-appoint btn-lg">Solução de controvérsias</a>
             </div>
             <div class="overlay-detail text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,6 @@ Rails.application.routes.draw do
     # /apoioaempresas
     get '/', to: 'calls#index' # Apoio a Empresas root
 
-    # /apoioaempresas/login
-    get '/login', to: 'visitors#index'
 
     # /apoioaempresas/attachments
     resources :attachments do


### PR DESCRIPTION
Now we can acess user and devise stuff without the '/apoioaempresas' prefix